### PR TITLE
this adds a new key 'inputs' inside options to get custom parameters

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.idea
+examples

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ media transcode -i ./my-input-file.wav -o ./my-output-file.mp3 -f mp3
 </pre>
 
 #### Using Code
-You can quickly transcode an audio file using `transcodeMediaFile` method.
+You can quickly transcode any audio/video file using `transcodeMediaFile` method.
 
 ```javascript
 const {transcodeMediaFile} = require('symbl-media');

--- a/examples/transcodeMediaFile.js
+++ b/examples/transcodeMediaFile.js
@@ -8,3 +8,14 @@ const {transcodeMediaFile} = require('../index');
         console.error(e);
     }
 })();
+
+// using the options object to pass custom inputs for transcoding
+
+(async () => {
+    try {
+        const result = await transcodeMediaFile('./example-audio.ts', 'my-output-file.wav', 'wav', {inputs: ['-vn']});
+        console.log('Successfully transcoded to: ', result.outPath);
+    } catch (e) {
+        console.error(e);
+    }
+})();

--- a/lib/media/index.js
+++ b/lib/media/index.js
@@ -61,11 +61,12 @@ const transcodeMediaFile = (inputFile, outputFile, outputFormat, options = {}) =
         throw `Third argument 'outputFormat' must be provided.`
     }
 
-    const {audioChannels} = options;
+    const {audioChannels, inputs = []} = options;
     let _audioChannels = audioChannels || 1;
     return new Promise((resolve, reject) => {
         ffmpeg(inputFile)
             .format(outputFormat)
+            .inputOptions(inputs)
             .audioChannels(_audioChannels)
             .on('end', () => {
                 resolve({

--- a/lib/media/index.js
+++ b/lib/media/index.js
@@ -108,21 +108,36 @@ const transcodeMediaFileStream = (inputFileStream, outputFileStream, outputForma
         throw `Third argument 'outputFormat' must be provided.`
     }
 
-    const {audioChannels} = options;
+    const {audioChannels, preserveChannelsAndLayout} = options;
     let _audioChannels = audioChannels || 1;
+
     return new Promise((resolve, reject) => {
-        ffmpeg(inputFileStream)
-            .format(outputFormat)
-            .audioChannels(_audioChannels)
-            .on('end', () => {
-                resolve({
-                    outPath: outputFileStream.path,
-                });
-            })
-            .on('error', (err) => {
-                reject(err);
-            })
-            .pipe(outputFileStream, { end: true });
+        if (preserveChannelsAndLayout) {
+            ffmpeg(inputFileStream)
+                .format(outputFormat)
+                .on('end', () => {
+                    resolve({
+                        outPath: outputFileStream.path,
+                    });
+                })
+                .on('error', (err) => {
+                    reject(err);
+                })
+                .pipe(outputFileStream, {end: true});
+        } else {
+            ffmpeg(inputFileStream)
+                .format(outputFormat)
+                .audioChannels(_audioChannels)
+                .on('end', () => {
+                    resolve({
+                        outPath: outputFileStream.path,
+                    });
+                })
+                .on('error', (err) => {
+                    reject(err);
+                })
+                .pipe(outputFileStream, {end: true});
+        }
     });
 };
 

--- a/lib/media/index.js
+++ b/lib/media/index.js
@@ -46,6 +46,7 @@ const transcodeMediaFiles = async (files = [], outputFormat) => {
  * @param {String} outputFormat format string
  * @param {Object} [options] additional options
  * @param {Number} [options.audioChannels] No. of audio channels
+ * @param {Array} [options.inputs] Custom input options for ffmpeg
  * @return {Promise<{}>}
  */
 const transcodeMediaFile = (inputFile, outputFile, outputFormat, options = {}) => {
@@ -90,6 +91,7 @@ const transcodeMediaFile = (inputFile, outputFile, outputFormat, options = {}) =
  * @param {String} outputFormat format string
  * @param {Object} [options] additional options
  * @param {Number} [options.audioChannels] No. of audio channels
+ * @param {Array} [options.inputs] Custom input options for ffmpeg
  * @return {Promise<{}>}
  */
 const transcodeMediaFileStream = (inputFileStream, outputFileStream, outputFormat, options = {}) => {
@@ -109,11 +111,12 @@ const transcodeMediaFileStream = (inputFileStream, outputFileStream, outputForma
         throw `Third argument 'outputFormat' must be provided.`
     }
 
-    const {audioChannels} = options;
+    const {audioChannels, inputs = []} = options;
     let _audioChannels = audioChannels || 1;
     return new Promise((resolve, reject) => {
         ffmpeg(inputFileStream)
             .format(outputFormat)
+            .inputOptions(inputs)
             .audioChannels(_audioChannels)
             .on('end', () => {
                 resolve({

--- a/lib/media/index.js
+++ b/lib/media/index.js
@@ -46,6 +46,7 @@ const transcodeMediaFiles = async (files = [], outputFormat) => {
  * @param {String} outputFormat format string
  * @param {Object} [options] additional options
  * @param {Number} [options.audioChannels] No. of audio channels
+ * @param {Array} [options.inputs] Custom input options for ffmpeg
  * @return {Promise<{}>}
  */
 const transcodeMediaFile = (inputFile, outputFile, outputFormat, options = {}) => {
@@ -90,6 +91,7 @@ const transcodeMediaFile = (inputFile, outputFile, outputFormat, options = {}) =
  * @param {String} outputFormat format string
  * @param {Object} [options] additional options
  * @param {Number} [options.audioChannels] No. of audio channels
+ * @param {Array} [options.inputs] Custom input options for ffmpeg
  * @return {Promise<{}>}
  */
 const transcodeMediaFileStream = (inputFileStream, outputFileStream, outputFormat, options = {}) => {
@@ -109,12 +111,13 @@ const transcodeMediaFileStream = (inputFileStream, outputFileStream, outputForma
         throw `Third argument 'outputFormat' must be provided.`
     }
 
-    const {audioChannels, preserveChannelsAndLayout} = options;
+    const {audioChannels, preserveChannelsAndLayout, inputs = []} = options;
     let _audioChannels = audioChannels || 1;
 
     return new Promise((resolve, reject) => {
         if (preserveChannelsAndLayout) {
             ffmpeg(inputFileStream)
+                .inputOptions(inputs)
                 .format(outputFormat)
                 .on('end', () => {
                     resolve({
@@ -127,8 +130,9 @@ const transcodeMediaFileStream = (inputFileStream, outputFileStream, outputForma
                 .pipe(outputFileStream, {end: true});
         } else {
             ffmpeg(inputFileStream)
-                .format(outputFormat)
+                .inputOptions(inputs)
                 .audioChannels(_audioChannels)
+                .format(outputFormat)
                 .on('end', () => {
                     resolve({
                         outPath: outputFileStream.path,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,19 +1,25 @@
-export const isStream = (stream) => {
+const isStream = (stream) => {
     return stream !== null
         && typeof stream === 'object'
         && typeof stream.pipe === 'function';
 };
 
-export const isReadableStream = (stream) => {
+const isReadableStream = (stream) => {
     return isStream(stream)
         && stream.readable !== false
         && typeof stream._read === 'function'
         && typeof stream._readableState === 'object';
 };
 
-export const isWritableStream = (stream) => {
+const isWritableStream = (stream) => {
     return isStream(stream)
         && stream.writable !== false
         && typeof stream._write === 'function'
         && typeof stream._writableState === 'object';
 };
+
+module.exports = {
+    isStream,
+    isReadableStream,
+    isWritableStream,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symbl-media",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbl-media",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Convenience tools to convert your media",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbl-media",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Convenience tools to convert your media",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
to transcode some audio files (like .ts) requires additional parameters to transcode. For e.g.
`ffmpeg -i example.ts -vn output.wav`

This PR adds an additional key inside options object which takes in a array of inputs. This utilizes the base library fluent-ffmpeg's `inputOptions` method:

```
ffmpeg('/path/to/file.avi').inputOptions([
  '-option1',
  '-option2 param2',
  '-option3',
  '-option4 param4'
]);
```